### PR TITLE
Add FastLapackInterface to reduce memory allocations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,9 @@ version = "1.0.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+FastLapackInterface = "29a986be-02c6-4525-aec4-84b980013641"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
-UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [weakdeps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
@@ -20,14 +19,13 @@ NCMJuMPExt = "JuMP"
 Aqua = "0.8"
 COSMO = "0.8"
 CommonSolve = "0.2"
+FastLapackInterface = "2"
 JuMP = "1.20"
 JuliaFormatter = "1"
 LinearAlgebra = "<0.0.1, 1"
 PrecompileTools = "1.2"
 SafeTestsets = "0.1"
 Test = "1"
-Tullio = "0.3.6"
-UnPack = "1"
 julia = "1.10"
 
 [extras]

--- a/src/NearestCorrelationMatrix.jl
+++ b/src/NearestCorrelationMatrix.jl
@@ -2,7 +2,7 @@ module NearestCorrelationMatrix
 
 using LinearAlgebra
 using CommonSolve: CommonSolve, init, solve, solve!
-using UnPack
+using FastLapackInterface: HermitianEigenWs
 
 include("internals/Internals.jl")
 using .Internals

--- a/src/algorithms/newton.jl
+++ b/src/algorithms/newton.jl
@@ -80,11 +80,11 @@ end
 
 function init_cacheval(::Newton, A, maxiters, abstol, reltol, verbose)
     ws = if A isa Symmetric
-        HermitianEigenWs(A.data, vecs=true)
+        HermitianEigenWs(A.data; vecs=true)
     elseif A isa Matrix
-        HermitianEigenWs(A, vecs=true)
+        HermitianEigenWs(A; vecs=true)
     else
-        HermitianEigenWs(Matrix(A), vecs=true)
+        HermitianEigenWs(Matrix(A); vecs=true)
     end
 
     return NewtonWorkspace(ws)

--- a/src/algorithms/newton.jl
+++ b/src/algorithms/newton.jl
@@ -71,7 +71,7 @@ end
 
 modifies_in_place(::Newton) = false
 supports_symmetric(::Newton) = true
-supports_float16(::Newton) = true
+supports_float16(::Newton) = false
 supports_parameterless_construction(::Newton) = true
 
 struct NewtonWorkspace{W}

--- a/src/internals/common.jl
+++ b/src/internals/common.jl
@@ -1,5 +1,5 @@
 using LinearAlgebra
-using LinearAlgebra: sorteig!
+using LinearAlgebra: sorteig!, eigencopy_oftype, eigtype
 
 using FastLapackInterface: LAPACK.syevr!
 
@@ -255,12 +255,17 @@ end
 eigen_sym(X, uplo=:U) = eigen_sym(Symmetric(X, uplo))
 
 function eigen_sym(ws, X::AbstractMatrix; sortby::Function=x -> -x)
+    S = eigtype(eltype(X))
+    return eigen_sym!(ws, eigencopy_oftype(X, S); sortby=sortby)
+end
+
+function eigen_sym!(ws, X::AbstractMatrix; sortby::Function=x -> -x)
     λ, P = LAPACK.syevr!(ws, 'V', 'A', 'U', X, 0.0, 0.0, 0, 0, -1.0)
     return Eigen(sorteig!(λ, P, sortby)...)
 end
 
-function eigen_sym(ws, X::Symmetric; sortby::Function=x -> -x)
-    λ, P = LAPACK.syevr!(ws, 'V', 'A', X.uplo, X.data, 0.0, 0.0, 0, 0, -1.0)
+function eigen_sym!(ws, X::Symmetric; sortby::Function=x -> -x)
+    λ, P = LAPACK.syevr!(ws, 'V', 'A', X.uplo, copy(X.data), 0.0, 0.0, 0, 0, -1.0)
     return Eigen(sorteig!(λ, P, sortby)...)
 end
 

--- a/src/internals/common.jl
+++ b/src/internals/common.jl
@@ -1,4 +1,7 @@
 using LinearAlgebra
+using LinearAlgebra: sorteig!
+
+using FastLapackInterface: LAPACK.syevr!
 
 export get_negdef_matrix,
     rand_negdef,
@@ -250,6 +253,16 @@ function eigen_sym(X::Symmetric{Float16})
 end
 
 eigen_sym(X, uplo=:U) = eigen_sym(Symmetric(X, uplo))
+
+function eigen_sym(ws, X::AbstractMatrix; sortby::Function=x -> -x)
+    λ, P = LAPACK.syevr!(ws, 'V', 'A', 'U', X, 0.0, 0.0, 0, 0, -1.0)
+    return Eigen(sorteig!(λ, P, sortby)...)
+end
+
+function eigen_sym(ws, X::Symmetric; sortby::Function=x -> -x)
+    λ, P = LAPACK.syevr!(ws, 'V', 'A', X.uplo, X.data, 0.0, 0.0, 0, 0, -1.0)
+    return Eigen(sorteig!(λ, P, sortby)...)
+end
 
 """
     project_psd!(X, ϵ)

--- a/src/internals/common.jl
+++ b/src/internals/common.jl
@@ -254,19 +254,16 @@ end
 
 eigen_sym(X, uplo=:U) = eigen_sym(Symmetric(X, uplo))
 
-function eigen_sym(ws, X::AbstractMatrix; sortby::Function=x -> -x)
+function eigen_sym(ws, X::Symmetric)
     S = eigtype(eltype(X))
-    return eigen_sym!(ws, eigencopy_oftype(X, S); sortby=sortby)
+    return eigen_sym!(ws, eigencopy_oftype(X, S))
 end
 
-function eigen_sym!(ws, X::AbstractMatrix; sortby::Function=x -> -x)
-    λ, P = LAPACK.syevr!(ws, 'V', 'A', 'U', X, 0.0, 0.0, 0, 0, -1.0)
-    return Eigen(sorteig!(λ, P, sortby)...)
-end
-
-function eigen_sym!(ws, X::Symmetric; sortby::Function=x -> -x)
+function eigen_sym!(ws, X::Symmetric)
     λ, P = LAPACK.syevr!(ws, 'V', 'A', X.uplo, copy(X.data), 0.0, 0.0, 0, 0, -1.0)
-    return Eigen(sorteig!(λ, P, sortby)...)
+    reverse!(λ)
+    reverse!(P; dims=2)
+    return Eigen(λ, P)
 end
 
 """

--- a/src/internals/newton_internals.jl
+++ b/src/internals/newton_internals.jl
@@ -112,7 +112,6 @@ function omega_matrix!(Ω, λ)
     return @view Ω[begin:r, r+1:end]
 end
 
-
 """
     perturb(x)
 

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -71,7 +71,8 @@ function CommonSolve.init(
     verbose::Bool=false,
     kwargs...
 )
-    @unpack A, p = prob
+    A = prob.A
+    p = prob.p
 
     A = if alias_A
         verbose && println("Aliasing A")


### PR DESCRIPTION
This change will essentially cut the number of allocations for the Newton method in half. However testing shows no improvement or regression in performance.