### PR TITLE
Fix and Simplify AlternatingProjections

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NearestCorrelationMatrix"
 uuid = "59ddf330-608c-4938-8bc9-a4ee97bbbea6"
 authors = ["Alex Knudson <alexk.706@gmail.com> and contributors"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/src/algorithms/alternatingprojections.jl
+++ b/src/algorithms/alternatingprojections.jl
@@ -28,10 +28,6 @@ function CommonSolve.solve!(solver::NCMSolver, alg::AlternatingProjections; kwar
     n = size(Y, 1)
     T = eltype(Y)
 
-    W = Diagonal(ones(T, n))
-    WHalf = sqrt(W)
-    WHalfInv = inv(WHalf)
-
     R = similar(Y)
     X = similar(Y)
     S = zeros(T, n, n)
@@ -41,7 +37,7 @@ function CommonSolve.solve!(solver::NCMSolver, alg::AlternatingProjections; kwar
 
     while i < solver.maxiters && resid ≥ solver.reltol
         @. R = Y - S
-        X .= project_s(R, WHalf, WHalfInv)
+        X .= project_s(R)
         @. S = X - R
         Y .= project_u(X)
 

--- a/src/algorithms/alternatingprojections.jl
+++ b/src/algorithms/alternatingprojections.jl
@@ -36,26 +36,17 @@ function CommonSolve.solve!(solver::NCMSolver, alg::AlternatingProjections; kwar
     X = similar(Y)
     S = zeros(T, n, n)
 
-    Yold = similar(Y)
-    Xold = similar(Y)
-
     i = 0
     resid = Inf
 
     while i < solver.maxiters && resid ≥ solver.reltol
-        Yold .= Y
-        Xold .= X
-
-        R .= Y - S
+        @. R = Y - S
         X .= project_s(R, WHalf, WHalfInv)
-        S .= X - R
+        @. S = X - R
         Y .= project_u(X)
 
-        rel_y = norm(Y - Yold, Inf) / norm(Y, Inf)
-        rel_x = norm(X - Xold, Inf) / norm(X, Inf)
-        rel_yx = norm(Y - X, Inf) / norm(Y, Inf)
-
-        resid = max(rel_x, rel_y, rel_yx)
+        # ref (4.1). Only need ‖Y-X‖/‖Y‖, and don't need ‖Xₖ-Xₖ₋₁‖\‖Xₖ‖ nor ‖Yₖ-Yₖ₋₁‖\‖Yₖ‖
+        resid = norm(Y .- X, Inf) / norm(Y, Inf)
 
         i += 1
     end

--- a/src/internals/ap_internals.jl
+++ b/src/internals/ap_internals.jl
@@ -13,6 +13,13 @@ function project_s(X, Whalf, Whalfinv)
 end
 
 """
+    project_s(X)
+
+Project ``X`` onto the set of symmetric positive semi-definite matrices.
+"""
+project_s(X) = Symmetric(project_psd(X))
+
+"""
     project_u(X)
 
 Project ``X`` onto the set of symmetric matrices with unit diagonal.


### PR DESCRIPTION
Fixes #29. Removed the triple residual calculation because, according to the reference paper, all three residuals are usually on the same order of magnitude, so only the Y-X residual is needed. This allows me to remove the `Yold` and `Xold` variables, and thus fix the initialization of `X` and `Xold`.

Additionally, I removed the W-norm from the algorithm since it only ever defaulted to an identity matrix. In the future we may add this back in, and potentially also support an H-norm matrix.